### PR TITLE
Fix nested resource

### DIFF
--- a/src/RestfulRouting/RouteSet.cs
+++ b/src/RestfulRouting/RouteSet.cs
@@ -143,7 +143,8 @@ namespace RestfulRouting
 
 			if (_currentMapping != null && _currentMapping.GetType().Name.StartsWith("ResourcesMapping")) // this sucks
 			{
-				_pathPrefix += "/{id}";
+				var singular = Singularize(_currentMapping.ResourceName).ToLowerInvariant();
+				_pathPrefix += "/{" + singular + "Id}";
 			}
 
 			var resourcesMapping = new ResourceMapping<TController>(_names, new ResourceMapper(_names, _pathPrefix, _routeHandler));

--- a/src/RestfulRouting/RouteSet.cs
+++ b/src/RestfulRouting/RouteSet.cs
@@ -141,10 +141,10 @@ namespace RestfulRouting
 
 			GenerateNestedPathPrefix();
 
-            if (_currentMapping != null && _currentMapping.GetType().Name.StartsWith("ResourcesMapping")) // this sucks
-            {
-                _pathPrefix += "/{id}";
-            }
+			if (_currentMapping != null && _currentMapping.GetType().Name.StartsWith("ResourcesMapping")) // this sucks
+			{
+				_pathPrefix += "/{id}";
+			}
 
 			var resourcesMapping = new ResourceMapping<TController>(_names, new ResourceMapper(_names, _pathPrefix, _routeHandler));
 


### PR DESCRIPTION
This fixes an issue for me where a nested Resource would not be mapped correctly according to the nested id column.

Example:

Resources<Magazines>(() =>
{
    Resources<Ads>();
    Resource<Frontpage>();
});

In this example the following nested routes would be mapped:

/magazines/{magazineId}/ads
/magazines/{id}/frontpage

But the problem is with the singular ressource, the route id should also be magazineId, or else I would have to specify this concretely when creating ActionLinks etc.
